### PR TITLE
Fix typos and ignore build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ next-env.d.ts
 /playwright/.cache/
 
 certificates
+tsconfig.tsbuildinfo

--- a/components/gamelist.tsx
+++ b/components/gamelist.tsx
@@ -43,10 +43,10 @@ const GameId = styled("div")({ fontSize: "0.8em" });
 
 const GameList = (props: {
   games: Game[];
-  pagenation?: boolean;
+  pagination?: boolean;
   hover?: boolean;
 }) => {
-  const pagenation = props.pagenation ?? true;
+  const pagination = props.pagination ?? true;
   const hover = props.hover ?? true;
   const games = props.games;
 
@@ -199,7 +199,7 @@ const GameList = (props: {
                       color: game.name ? "black" : "gray",
                     }}
                   >
-                    {game.name || "Untitle"}
+                    {game.name || "Untitled"}
                   </Link>
                   <GameId>{game.id}</GameId>
                 </TableCell>
@@ -207,7 +207,7 @@ const GameList = (props: {
               </TableRow>
             ))}
           </TableBody>
-          {pagenation && (
+          {pagination && (
             <TableFooter>
               <TableRow>
                 <TablePagination


### PR DESCRIPTION
## Summary
- fix typos in GameList component
- ignore TypeScript build cache file

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file)*