### PR TITLE
Fix component export name

### DIFF
--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -196,7 +196,7 @@ function Cell({
   );
 }
 
-export default function Gamefield({
+export default function GameBoard({
   game: { field, players, log, nAgent },
   users,
   nextTiles,


### PR DESCRIPTION
## Summary
- rename Gamefield component to GameBoard

## Testing
- `npm run lint` *(fails: `next` not found)*