### PR TITLE
Improve viewer performance

### DIFF
--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import Image from "next/image";
 import { keyframes, styled } from "@mui/material/styles";
 import { useResizeDetector } from "react-resize-detector";
@@ -152,7 +152,7 @@ const StyledNextTile = styled("div")({
   justifyContent: "center",
 });
 
-function Cell({
+const Cell = React.memo(function Cell({
   point,
   i,
   nAgent,
@@ -170,7 +170,7 @@ function Cell({
   bgColor: string;
   nConflict: number;
   isAbs: boolean;
-}) {
+  }) {
   const animation = useMemo(() => {
     return nConflict > 0
       ? `${flash} ${1 - (0.6 / nAgent) * nConflict}s linear infinite`
@@ -194,7 +194,7 @@ function Cell({
       {isAbs && <span>{Math.abs(point)}</span>}
     </StyledCell>
   );
-}
+});
 
 export default function Gamefield({
   game: { field, players, log, nAgent },

--- a/components/gamePanel.tsx
+++ b/components/gamePanel.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { Box, Skeleton, Button, Paper } from "@mui/material";
 
-import GameBoard from "./gameBoard";
-import PointsGraph from "./pointsGraph";
+import dynamic from "next/dynamic";
+
+const GameBoard = dynamic(() => import("./gameBoard"));
+const PointsGraph = dynamic(() => import("./pointsGraph"), { ssr: false });
 import datas from "./player_datas";
 
 import { Game } from "../src/apiClient";


### PR DESCRIPTION
## Summary
- memoize Gameboard Cell rendering to reduce rerenders
- lazily load heavy components with `next/dynamic`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails to find modules)*